### PR TITLE
improve docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
-/back/node_modules
-/front/node_modules
-/front/dist
+node_modules/
+dist/
 npm-debug.log
 .git
 .gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,30 @@
 # build stage
-FROM node:lts-alpine as build-stage
-WORKDIR /app
-COPY ./front/package*.json ./front/
-RUN cd front && npm install
-COPY ./front ./front/
-RUN cd front && npm run build
-COPY ./back/package*.json ./back/
-RUN cd back && npm install
-COPY ./back ./back/
-WORKDIR /app/back
+FROM node:lts-alpine as base
+RUN mkdir -p /app/front
+RUN mkdir -p /app/back
 
+# ---- Build ----
+FROM base AS build-stage
+
+WORKDIR /app
+COPY . .
+
+WORKDIR /app/front
+RUN npm install && npm rebuild node-sass && npm run build
+
+WORKDIR /app/back
+RUN npm install --only=production
+
+# ---- Release ----
+FROM base AS release
+
+LABEL description="Let you fill redmine timesheet automatically by daterange"
+
+COPY --from=build-stage /app/front/dist /app/front/dist
+COPY --from=build-stage /app/back /app/back
+
+WORKDIR /app/back
+USER node
 EXPOSE 3000
+
 CMD ["npm", "run", "start"]


### PR DESCRIPTION
Featuring:
- multi-stage with only prod package (286.7MB => 96.11MB)
- run nodejs as unprivileged user
